### PR TITLE
:rocket: Add deployment with gunicorn and fix few dockerfile issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
 FROM python:3.8
-MAINTAINER meetup@piterpy.ru
-
-ENV PORT=8000
-ENV HOST=0.0.0.0
 
 WORKDIR /opt/project
 
-ADD pyproject.toml poetry.lock /opt/project/
+COPY pyproject.toml poetry.lock /opt/project/
 
 # Turn off auto creation of venvs, use system-wide python in docker image
 RUN pip install poetry>=1.0.0 && \
     poetry config virtualenvs.create false && \
-    poetry install
+    poetry install && \
+    pip install gunicorn==20
 
-ADD . /opt/project/
+COPY . /opt/project/
 
-CMD uvicorn --host=$HOST --port=$PORT c4p2n.api:app
+CMD ["gunicorn", "c4p2n.api:app", "--workers=1", "--worker-class=uvicorn.workers.UvicornWorker", "--bind=0.0.0.0:8000"]


### PR DESCRIPTION
uvicorn and FastAPI documentation recommends deploy to production via gunicorn: https://www.uvicorn.org/#running-with-gunicorn, so I rewrote CMD to JSON-like gunicorn runner.

Removed maintainer (https://github.com/hadolint/hadolint/wiki/DL4000)

ADD was replaced to COPY (https://github.com/hadolint/hadolint/wiki/DL3020)